### PR TITLE
Bump electron to 39 - fix linux gtk rendering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "@vitest/ui": "^4.0.16",
         "autoprefixer": "^10.4.21",
         "dotenv": "^17.0.0",
-        "electron": "36.8.1",
+        "electron": "39.3.0",
         "eslint": "^8.57.1",
         "eslint-import-resolver-alias": "^1.1.2",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -9289,9 +9289,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "36.8.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-36.8.1.tgz",
-      "integrity": "sha512-honaH58/cyCb9QAzIvD+WXWuNIZ0tW9zfBqMz5wZld/rXB+LCTEDb2B3TAv8+pDmlzPlkPio95RkUe86l6MNjg==",
+      "version": "39.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-39.3.0.tgz",
+      "integrity": "sha512-ZA2Cmu5Vs8zeuZBr71XWZ5vgm7lRDB9N50oV6ee7YocITyxRxx/apWFKY48Sxyn0gzVlX+6YQc3CS1PtYIkGUg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@vitest/ui": "^4.0.16",
     "autoprefixer": "^10.4.21",
     "dotenv": "^17.0.0",
-    "electron": "36.8.1",
+    "electron": "39.3.0",
     "eslint": "^8.57.1",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
[Electron 36 has an error](https://github.com/electron/electron/issues/46538) preventing rendering on some linux gtk platforms. This bumps to the latest stable electron version. 